### PR TITLE
Implement check with exit code in the npm port of license-header

### DIFF
--- a/npm-packages/license-header/command.mjs
+++ b/npm-packages/license-header/command.mjs
@@ -26,7 +26,7 @@ if (!args.ok) {
     process.exit(1);
 }
 if (args.help) {
-    console.log(`USAGE: license-header [path] [--ignore glob-pattern...] [--license-type ${Object.keys(licenses).join("|")}] [--year-range text] [--copyright-holder text]`);
+    console.log(`USAGE: license-header [path] [--ignore glob-pattern...] [--check] [--license-type ${Object.keys(licenses).join("|")}] [--year-range text] [--copyright-holder text]`);
     console.log(`As an alternative to the command line, license properties can be defined in package.json under "licenseHeader".`);
     process.exit(0);
 }
@@ -55,7 +55,7 @@ if (!lsFiles.ok) {
     process.exit(1);
 }
 
-let updated = 0;
+const updated = [];
 for (const filename of lsFiles.files) {
     try {
         const data = readFileSync(filename, "utf-8");
@@ -67,14 +67,26 @@ for (const filename of lsFiles.files) {
             data
         );
         if (data !== result) {
-            writeFileSync(filename, result, "utf-8");
-            updated++;
+            if (!args.check) {
+                writeFileSync(filename, result, "utf-8");
+            }
+            updated.push(filename);
         }
     } catch (e) {
         process.stderr.write(`${String(e)}\n`);
         process.exit(1);
     }
 }
-console.log(`updated ${updated} license headers in ${lsFiles.files.length} files.`);
+if (args.check) {
+    if (updated.length > 0) {
+        process.stderr.write(`missing license header in ${updated.length} files:\n`);
+        for (const file of updated) {
+            process.stderr.write(`${file}\n`);
+        }
+        process.exit(1);
+    }
+    process.exit(0);
+}
+console.log(`updated ${updated.length} license headers in ${lsFiles.files.length} files.`);
 
 

--- a/npm-packages/license-header/package.json
+++ b/npm-packages/license-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufbuild/license-header",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Handle license headers",
   "license": "Apache-2.0",
   "scripts": {

--- a/npm-packages/license-header/util.mjs
+++ b/npm-packages/license-header/util.mjs
@@ -39,6 +39,7 @@ import picomatch from "picomatch";
  * @property {string} [yearRange]
  * @property {string} [copyrightHolder]
  * @property {Array<string>} ignorePatterns
+ * @property {boolean} check
  * @property {boolean} version
  * @property {boolean} help
  */
@@ -52,6 +53,7 @@ export function parseCommandLineArgs(args) {
     const parsed = {
         ok: true,
         ignorePatterns: [],
+        check: false,
         version: false,
         help: false,
     }
@@ -67,6 +69,12 @@ export function parseCommandLineArgs(args) {
                 break;
             case "--version":
                 parsed.version = true;
+                break;
+            case "--check":
+                if (parsed.check) {
+                    break;
+                }
+                parsed.check = true;
                 break;
             case "--ignore":
                 const val = args.shift();

--- a/npm-packages/license-header/util.test.mjs
+++ b/npm-packages/license-header/util.test.mjs
@@ -103,6 +103,7 @@ describe("parseCommandLineArgs", () => {
             ok: true,
             path: ".",
             ignorePatterns: [],
+            check: false,
             version: false,
             help: false,
         });
@@ -125,6 +126,7 @@ describe("parseCommandLineArgs", () => {
         const c = parseCommandLineArgs([
             "--help",
             "--version",
+            "--check",
             "--ignore",
             "foo",
             "--ignore",
@@ -144,6 +146,7 @@ describe("parseCommandLineArgs", () => {
             licenseType: "fake-license",
             yearRange: "fake year",
             copyrightHolder: "fake owner",
+            check: true,
             version: true,
             help: true,
         });


### PR DESCRIPTION
This adds the capability to run check if license-headers are up-to-date without modifying them:

```bash
$ npx license-header --check
missing license header in 3 files:
testdata/files/a.js
testdata/files/b.js
testdata/files/c.js
$ echo $?
1
```