### PR TITLE
Add support for adding license to dot files

### DIFF
--- a/npm-packages/license-header/package.json
+++ b/npm-packages/license-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufbuild/license-header",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Handle license headers",
   "license": "Apache-2.0",
   "scripts": {

--- a/npm-packages/license-header/testdata/files/.eslintrc.js
+++ b/npm-packages/license-header/testdata/files/.eslintrc.js
@@ -1,0 +1,17 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const config = {};
+
+module.exports = config;

--- a/npm-packages/license-header/util.mjs
+++ b/npm-packages/license-header/util.mjs
@@ -268,7 +268,7 @@ export function gitLsFiles(opt) {
     const files = r.stdout.trim().split("\n");
     const matchInclude = opt?.include ?? "**/*";
     const matchIgnore = opt?.ignore ?? [];
-    const match = picomatch(matchInclude, {ignore: matchIgnore});
+    const match = picomatch(matchInclude, {ignore: matchIgnore, dot: true});
     return {
         ok: true,
         files: files.filter(f => match(f)),

--- a/npm-packages/license-header/util.test.mjs
+++ b/npm-packages/license-header/util.test.mjs
@@ -42,6 +42,7 @@ describe("gitLsFiles", () => {
             "config/golden/package.json",
             "config/incomplete/package.json",
             "config/invalid-type/package.json",
+            "files/.eslintrc.js",
             "files/a.js",
             "files/b.js",
             "files/c.js"

--- a/npm-packages/license-header/util.test.mjs
+++ b/npm-packages/license-header/util.test.mjs
@@ -27,6 +27,7 @@ describe("gitLsFiles", () => {
             "testdata/config/golden/package.json",
             "testdata/config/incomplete/package.json",
             "testdata/config/invalid-type/package.json",
+            "testdata/files/.eslintrc.js",
             "testdata/files/a.js",
             "testdata/files/b.js",
             "testdata/files/c.js"


### PR DESCRIPTION
We have a few .eslintrc.js files scattered around so the license tool should support adding licenses there as well.