### PR TITLE
Fix incorrect handling of deleted files in npm port of license-header

### DIFF
--- a/npm-packages/license-header/package.json
+++ b/npm-packages/license-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufbuild/license-header",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Handle license headers",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
The tool uses `git ls-files` to list files to process, but it fails to exclude deleted but unstaged files, and tries to update their license as well.