### PR TITLE
Fix Dockerfile for crossbuilds

### DIFF
--- a/cmd/protoc-gen-multi/README.md
+++ b/cmd/protoc-gen-multi/README.md
@@ -50,7 +50,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go install -ldflags "-s -w" github.com/bufbuild/tools/cmd/protoc-gen-multi@latest
 
 # Move binaries prefixed with GOOS_GOARCH to /go/bin.
-RUN mv /go/bin/${TARGETOS}_$TARGETARCH/* /go/bin || true
+RUN mv /go/bin/${TARGETOS}_${TARGETARCH}/* /go/bin || true
 
 # Build final image.
 FROM scratch

--- a/cmd/protoc-gen-multi/README.md
+++ b/cmd/protoc-gen-multi/README.md
@@ -40,18 +40,17 @@ FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS build
 ARG TARGETOS TARGETARCH
 
 # Add custom plugins here
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go install -ldflags "-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@v1.32 \
-    && go install -ldflags "-s -w" google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3 \
-    && go install -ldflags "-s -w" github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v0.5.0 \
-    && go install -ldflags "-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.19
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@v1.32 \
+    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3 \
+    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v0.5.0 \
+    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.19
 
 # Install protoc-gen-multi, must be installed.
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go install -ldflags "-s -w" github.com/bufbuild/tools/cmd/protoc-gen-multi@latest
 
 # Move binaries prefixed with GOOS_GOARCH to /go/bin.
-RUN mv /go/bin/$TARGETOS_$TARGETARCH/* /go/bin || true
+RUN mv /go/bin/${TARGETOS}_$TARGETARCH/* /go/bin || true
 
 # Build final image.
 FROM scratch

--- a/cmd/protoc-gen-multi/example/Dockerfile
+++ b/cmd/protoc-gen-multi/example/Dockerfile
@@ -3,18 +3,17 @@ FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS build
 ARG TARGETOS TARGETARCH
 
 # Add custom plugins here
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go install -ldflags "-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@v1.32 \
-    && go install -ldflags "-s -w" google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3 \
-    && go install -ldflags "-s -w" github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v0.5.0 \
-    && go install -ldflags "-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.19
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@v1.32 \
+    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3 \
+    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v0.5.0 \
+    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.19
 
 # Install protoc-gen-multi, must be installed.
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go install -ldflags "-s -w" github.com/bufbuild/tools/cmd/protoc-gen-multi@latest
 
 # Move binaries prefixed with GOOS_GOARCH to /go/bin.
-RUN mv /go/bin/$TARGETOS_$TARGETARCH/* /go/bin || true
+RUN mv /go/bin/${TARGETOS}_$TARGETARCH/* /go/bin || true
 
 # Build final image.
 FROM scratch


### PR DESCRIPTION
Correct the Dockerfile for crossbuilds. The following two issues were corrected:
- Set the env vars for each go install command
- Correct the move command to capture the `${TARGETOS}` correctly