### PR TITLE
Improve protoc-gen-multi Dockerfile

### DIFF
--- a/cmd/protoc-gen-multi/README.md
+++ b/cmd/protoc-gen-multi/README.md
@@ -39,15 +39,16 @@ Create a docker image with all the protoc plugins desired, plus `protoc-gen-mult
 FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS build
 ARG TARGETOS TARGETARCH
 
-# Add custom plugins here
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@v1.32 \
-    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3 \
-    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v0.5.0 \
-    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.19
+ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH 
 
 # Install protoc-gen-multi, must be installed.
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go install -ldflags "-s -w" github.com/bufbuild/tools/cmd/protoc-gen-multi@latest
+RUN go install -ldflags "-s -w" github.com/bufbuild/tools/cmd/protoc-gen-multi@latest
+
+# Add custom plugins here
+RUN go install -ldflags "-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@v1.32 \
+    && go install -ldflags "-s -w" google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3 \
+    && go install -ldflags "-s -w" github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v0.6.0 \
+    && go install -ldflags "-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.19
 
 # Move binaries prefixed with GOOS_GOARCH to /go/bin.
 RUN mv /go/bin/${TARGETOS}_${TARGETARCH}/* /go/bin || true
@@ -84,6 +85,8 @@ registry:
         version: v1.32.0
       - module: google.golang.org/grpc
         version: v1.3.0
+      - module: github.com/planetscale/vtprotobuf
+        version: v0.6.0
       - module: github.com/grpc-ecosystem/grpc-gateway/v2
         version: v2.19
   # Add the options to invoke each plugin for the generated SDK.

--- a/cmd/protoc-gen-multi/example/Dockerfile
+++ b/cmd/protoc-gen-multi/example/Dockerfile
@@ -2,18 +2,19 @@
 FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS build
 ARG TARGETOS TARGETARCH
 
-# Add custom plugins here
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@v1.32 \
-    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3 \
-    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v0.5.0 \
-    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.19
+ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH 
 
 # Install protoc-gen-multi, must be installed.
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go install -ldflags "-s -w" github.com/bufbuild/tools/cmd/protoc-gen-multi@latest
+RUN go install -ldflags "-s -w" github.com/bufbuild/tools/cmd/protoc-gen-multi@latest
+
+# Add custom plugins here
+RUN go install -ldflags "-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@v1.32 \
+    && go install -ldflags "-s -w" google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3 \
+    && go install -ldflags "-s -w" github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v0.6.0 \
+    && go install -ldflags "-s -w" github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.19
 
 # Move binaries prefixed with GOOS_GOARCH to /go/bin.
-RUN mv /go/bin/${TARGETOS}_$TARGETARCH/* /go/bin || true
+RUN mv /go/bin/${TARGETOS}_${TARGETARCH}/* /go/bin || true
 
 # Build final image.
 FROM scratch

--- a/cmd/protoc-gen-multi/example/buf.gen.yaml
+++ b/cmd/protoc-gen-multi/example/buf.gen.yaml
@@ -6,7 +6,7 @@ managed:
 plugins:
   # Use the plugin as a remote plugin.
   # NB: ensure BSR registry and version matches.
- - plugin: bufbuild.internal/local/multi:v1.0.3
+ - plugin: buf.example.com/custom-plugins/multi
    out: gen
    # Set the below options to invoke different commands.
    opt: --go_out=.

--- a/cmd/protoc-gen-multi/example/buf.plugin.yaml
+++ b/cmd/protoc-gen-multi/example/buf.plugin.yaml
@@ -1,5 +1,5 @@
 version: v1
-name: bufbuild.internal/local/multi # Change me to your BSR plugin repository.
+name: buf.example.com/custom-plugins/multi # Change me to your BSR plugin repository.
 plugin_version: v0.1.0 # Change me to your version.
 output_languages:
   - go
@@ -11,6 +11,8 @@ registry:
         version: v1.32
       - module: google.golang.org/grpc
         version: v1.3
+      - module: github.com/planetscale/vtprotobuf
+        version: v0.6.0
       - module: github.com/grpc-ecosystem/grpc-gateway/v2
         version: v2.19
   # Add the options to invoke each plugin for the generated SDK.

--- a/cmd/protoc-gen-multi/main.go
+++ b/cmd/protoc-gen-multi/main.go
@@ -70,6 +70,9 @@ func generate(ctx context.Context, args []string, request *pluginpb.CodeGenerato
 	if err != nil {
 		return fmt.Errorf("invalid argument: %w", err)
 	}
+	if len(plugins) == 0 {
+		return fmt.Errorf("no plugins specified, expected at least one plugin: --<name>_out=<out> --<name>_opt=<opt>")
+	}
 	group, ctx := errgroup.WithContext(ctx)
 	outs := make([]pluginpb.CodeGeneratorResponse, len(plugins))
 	for i, plugin := range plugins {


### PR DESCRIPTION
Improve the Dockerfile example for better caching and tidy up env vars. Also updated the vt proto to the latest version 0.6 which adds a runtime dependency to the generated SDK. Tested within staging. 

Also included is improved handling of the case where zero plugins are specified. This will now error asking you to specify plugins to run.