### PR TITLE
Create add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -1,0 +1,21 @@
+name: Add issues and PRs to project
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  call-workflow-add-to-project:
+    name: Call workflow to add issue to project
+    uses: bufbuild/base-workflows/.github/workflows/add-to-project.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Creates GitHub workflow to add new issues/PRs to the project board, using the existing shared workflow. We first tested this in https://github.com/bufbuild/knit/pull/28