### PR TITLE
Update to go 1.22 and golangci-lint 1.60.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -23,34 +21,27 @@ linters:
   enable-all: true
   disable:
     - cyclop            # covered by gocyclo
-    - deadcode          # abandoned
-    - exhaustivestruct  # replaced by exhaustruct
+    - depguard          # unnecessary for small libraries
+    - execinquery       # deprecated in golangci v1.58 
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
-    - interfacer        # deprecated by author
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
     - nlreturn          # generous whitespace violates house style
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
     - testpackage       # internal tests are fine
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
     - exhaustruct       # exhaustive struct checks are noisy
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
-    - "err113: do not define dynamic errors.*"
+    - "do not define dynamic errors.*"
   exclude-rules:
     # We don't want to list out all the fields for appcmd.Cmd or flags.
     - linters: [exhaustruct]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - gomnd             # deprecated in golangci v1.58
+    - gomnd             # deprecated in golangci v1.58 in favor of mnd
     - mnd               # some unnamed constants are okay
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,8 @@ linters:
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - gomnd             # some unnamed constants are okay
+    - gomnd             # deprecated in golangci v1.58
+    - mnd               # some unnamed constants are okay
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo

--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,4 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0

--- a/cmd/license-header/main.go
+++ b/cmd/license-header/main.go
@@ -177,7 +177,7 @@ func run(ctx context.Context, container app.Container, flags *flags) error {
 						return err
 					}
 					if flags.ExitCode {
-						return app.NewError(100, "")
+						return app.NewError(100, "") //nolint:mnd
 					}
 				}
 			} else {

--- a/cmd/license-header/main.go
+++ b/cmd/license-header/main.go
@@ -177,7 +177,7 @@ func run(ctx context.Context, container app.Container, flags *flags) error {
 						return err
 					}
 					if flags.ExitCode {
-						return app.NewError(100, "") //nolint:mnd
+						return app.NewError(100, "")
 					}
 				}
 			} else {

--- a/cmd/protoc-gen-by-dir/main.go
+++ b/cmd/protoc-gen-by-dir/main.go
@@ -76,7 +76,6 @@ func handle(
 	}
 	jobs := make([]func(context.Context) error, 0, len(requestsByDir))
 	for _, requestByDir := range requestsByDir {
-		requestByDir := requestByDir
 		jobs = append(
 			jobs,
 			func(ctx context.Context) error {
@@ -96,8 +95,8 @@ func handle(
 
 func getEnv(environ []string, key string) string {
 	for _, e := range environ {
-		split := strings.SplitN(e, "=", 2)
-		if len(split) != 2 {
+		split := strings.SplitN(e, "=", 2) //nolint:mnd
+		if len(split) != 2 {               //nolint:mnd
 			continue
 		}
 		if split[0] == key {

--- a/cmd/protoc-gen-by-dir/main.go
+++ b/cmd/protoc-gen-by-dir/main.go
@@ -95,8 +95,8 @@ func handle(
 
 func getEnv(environ []string, key string) string {
 	for _, e := range environ {
-		split := strings.SplitN(e, "=", 2) //nolint:mnd
-		if len(split) != 2 {               //nolint:mnd
+		split := strings.SplitN(e, "=", 2)
+		if len(split) != 2 {
 			continue
 		}
 		if split[0] == key {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/tools
 
-go 1.21
+go 1.22
 
 require (
 	github.com/bufbuild/buf v1.30.1-0.20240319161122-65f8d5b50bdd


### PR DESCRIPTION
Now that a new version of Go has been released, this bumps the versions used in this repo.

This also updates golangci-lint to the latest, which called for some config changes to eliminate warnings.