### PR TITLE
Add npm package @bufbuild/protocompile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,5 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install dependencies
-        run: npm ci
-      - name: Test
-        run: npm test
+      - run: npm ci
+      - run: npm run -ws all

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.tmp/
 /license-header
 /protoc-gen-by-dir
+/npm-packages/*/dist
 *.pprof
 *.svg
 cover.out

--- a/npm-packages/license-header/README.md
+++ b/npm-packages/license-header/README.md
@@ -1,4 +1,4 @@
-# license-header
+# @bufbuild/license-header
 
 A tool to add and update license headers in source code.
 

--- a/npm-packages/license-header/package.json
+++ b/npm-packages/license-header/package.json
@@ -3,7 +3,13 @@
   "version": "0.0.4",
   "description": "Handle license headers",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bufbuild/tools.git",
+    "directory": "npm-packages/license-header"
+  },
   "scripts": {
+    "all": "node --test",
     "test": "node --test",
     "license-header": "license-header --ignore 'testdata/**'"
   },

--- a/npm-packages/protocompile/README.md
+++ b/npm-packages/protocompile/README.md
@@ -1,0 +1,32 @@
+# @bufbuild/protocompile
+
+This tool compiles descriptors from Protobuf on the fly.
+
+Do you need a message schema in your test? With the `compileMessage` function, you can compile inline Protobuf source to a message descriptor:
+
+```ts
+import { compileMessage } from "@bufbuild/protocompile";
+import { redact } from "./redact.js";
+
+describe("redact", () => {
+  it("should redact string field", () => {
+    const schema = compileMessage(`
+      syntax = "proto3";
+      message Example {
+        string foo = 1 [ debug_redact = true ];
+      }
+    `);
+    const message: Message & Record<string, unknown> = create(schema, {
+      foo: "abc",
+    });
+    redact(message);
+    expect(message.foo).toBe("");
+  });
+});
+```
+
+The package also exports functions to compile Protobuf descriptors for all other types, such as enumerations and services.
+
+Under the hood, the functions shell out to the `buf build` command. You have to install [@bufbuild/buf](https://www.npmjs.com/package/@bufbuild/buf) to use them.
+
+Note that the functions return anonymous descriptors. They are functionally identical to generated descriptors, but do not have generated type information attached.

--- a/npm-packages/protocompile/README.md
+++ b/npm-packages/protocompile/README.md
@@ -27,6 +27,6 @@ describe("redact", () => {
 
 The package also exports functions to compile Protobuf descriptors for all other types, such as enumerations and services.
 
-Under the hood, the functions shell out to the `buf build` command. You have to install [@bufbuild/buf](https://www.npmjs.com/package/@bufbuild/buf) to use them.
+Under the hood, the functions shell out to the `buf build` command. You need [@bufbuild/buf](https://www.npmjs.com/package/@bufbuild/buf) as a peer dependency to use them.
 
 Note that the functions return anonymous descriptors. They are functionally identical to generated descriptors, but do not have generated type information attached.

--- a/npm-packages/protocompile/package-lock.json
+++ b/npm-packages/protocompile/package-lock.json
@@ -1,16 +1,27 @@
 {
-  "name": "tools",
+  "name": "@bufbuild/protocompile",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "workspaces": [
-        "./npm-packages/license-header",
-        "./npm-packages/protocompile"
-      ],
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
+      "name": "@bufbuild/protocompile",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.1.0",
+        "fflate": "^0.8.2"
+      },
+      "devDependencies": {
+        "@arethetypeswrong/cli": "^0.16.4",
+        "@bufbuild/buf": "^1.42.0",
+        "@types/node": "^22.7.0",
+        "prettier": "^3.3.3",
+        "tsx": "^4.19.1",
+        "typescript": "^5.6.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/buf": "^1.22.0"
       }
     },
     "node_modules/@andrewbranch/untar.js": {
@@ -189,14 +200,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@bufbuild/protocompile": {
-      "resolved": "npm-packages/protocompile",
-      "link": true
-    },
-    "node_modules/@bufbuild/license-header": {
-      "resolved": "npm-packages/license-header",
-      "link": true
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.1.0",
@@ -610,9 +613,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
-      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+      "version": "22.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.0.tgz",
+      "integrity": "sha512-MOdOibwBs6KW1vfqz2uKMlxq5xAfAZ98SZjO8e3XnAbFnTJtAspqhWk7hrdSAs9/Y14ZWMiy7/MxMUzAOadYEw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -1013,17 +1016,6 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/prettier": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
@@ -1263,36 +1255,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "npm-packages/protocompile": {
-      "version": "0.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bufbuild/protobuf": "^2.1.0",
-        "fflate": "^0.8.2"
-      },
-      "devDependencies": {
-        "@arethetypeswrong/cli": "^0.16.4",
-        "@bufbuild/buf": "^1.42.0",
-        "@types/node": "^22.7.0",
-        "prettier": "^3.3.3",
-        "tsx": "^4.19.1",
-        "typescript": "^5.6.2"
-      },
-      "peerDependencies": {
-        "@bufbuild/buf": "^1.22.0"
-      }
-    },
-    "npm-packages/license-header": {
-      "name": "@bufbuild/license-header",
-      "version": "0.0.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "picomatch": "^2.3.1"
-      },
-      "bin": {
-        "license-header": "command.mjs"
       }
     }
   }

--- a/npm-packages/protocompile/package.json
+++ b/npm-packages/protocompile/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@bufbuild/protocompile",
+  "version": "0.0.1",
+  "description": "Compile Protobuf on the fly for your tests",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bufbuild/tools.git",
+    "directory": "npm-packages/protocompile"
+  },
+  "scripts": {
+    "all": "npm run test && npm run build && npm run format && npm run attw",
+    "prebuild": "rm -rf ./dist/*",
+    "build": "tsc --project tsconfig.esm.json && tsc --project tsconfig.cjs.json",
+    "postbuild": "echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "test": "tsx --test src/*test.ts",
+    "format": "prettier --write --ignore-unknown . '!dist'",
+    "attw": "attw --pack",
+    "prepublish": "npm run build"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/cjs/index.js",
+  "files": [
+    "dist/**"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
+  "devDependencies": {
+    "@arethetypeswrong/cli": "^0.16.4",
+    "@bufbuild/buf": "^1.42.0",
+    "@types/node": "^22.7.0",
+    "prettier": "^3.3.3",
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.2"
+  },
+  "peerDependencies": {
+    "@bufbuild/buf": "^1.22.0"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": "^2.1.0",
+    "fflate": "^0.8.2"
+  }
+}

--- a/npm-packages/protocompile/src/buf-build.test.ts
+++ b/npm-packages/protocompile/src/buf-build.test.ts
@@ -1,3 +1,17 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { bufBuild } from "./buf-build.js";

--- a/npm-packages/protocompile/src/buf-build.test.ts
+++ b/npm-packages/protocompile/src/buf-build.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { bufBuild } from "./buf-build.js";
+
+describe("bufBuild()", () => {
+  it("should provide first file annotation for syntax error", () => {
+    const files = {
+      "input.proto": `syntax = "proto3";
+      
+      $
+      `,
+    };
+    assert.throws(() => bufBuild(files), /input.proto:3:3: invalid character/);
+  });
+  it("should provide stderr for without file annotation", () => {
+    const files = {
+      "input.proto": ``,
+    };
+    const flags = {
+      garbage: true,
+    };
+    assert.throws(() => bufBuild(files, flags), /unknown flag: --garbage/);
+  });
+});

--- a/npm-packages/protocompile/src/buf-build.ts
+++ b/npm-packages/protocompile/src/buf-build.ts
@@ -1,3 +1,17 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { spawnSync } from "node:child_process";
 import { zipSync } from "fflate";
 

--- a/npm-packages/protocompile/src/buf-build.ts
+++ b/npm-packages/protocompile/src/buf-build.ts
@@ -1,0 +1,109 @@
+import { spawnSync } from "node:child_process";
+import { zipSync } from "fflate";
+
+export type BufBuildFlags = {
+  excludeSourceInfo?: boolean;
+  excludeSourceRetentionOptions?: boolean;
+  asFileDescriptorSet?: boolean;
+};
+
+export function bufBuild(
+  files: Record<string, string>,
+  flags?: BufBuildFlags & TestFlags,
+): Uint8Array {
+  const zip = zipFiles(files);
+  const p = spawnSync(
+    "buf",
+    [
+      "build",
+      ...flagsToStrings(flags),
+      "--error-format=json",
+      "-#format=zip",
+      "--output",
+      "-",
+    ],
+    {
+      encoding: "buffer",
+      input: zip,
+      windowsHide: true,
+    },
+  );
+  if (p.error != undefined) {
+    throw p.error;
+  }
+  if (p.status !== 0) {
+    const stderr = p.stderr.toString();
+    if (p.status === 100) {
+      // Since v0.41.0, buf exits with code 100 for file annotations
+      const annotations = parseFileAnnotations(stderr);
+      if (annotations === null) {
+        throw new Error(stderr);
+      }
+      if (annotations.length == 0) {
+        throw new Error("failed to compile");
+      }
+      const first = annotations[0];
+      throw new Error(
+        `${first.path}:${first.start_line}:${first.end_line}: ${first.message}`,
+      );
+    } else {
+      throw new Error(stderr);
+    }
+  }
+  return p.stdout;
+}
+
+type TestFlags = {
+  garbage?: boolean;
+};
+
+function flagsToStrings(
+  flags: (BufBuildFlags & TestFlags) | undefined,
+): string[] {
+  const f: string[] = [];
+  if (flags !== undefined) {
+    if (flags.excludeSourceInfo) {
+      f.push("--exclude-source-info");
+    }
+    if (flags.excludeSourceRetentionOptions) {
+      f.push("--exclude-source-retention-options");
+    }
+    if (flags.asFileDescriptorSet) {
+      f.push("--as-file-descriptor-set");
+    }
+    if (flags.garbage) {
+      f.push("--garbage");
+    }
+  }
+  return f;
+}
+
+type FileAnnotation = {
+  path: string;
+  start_line: number;
+  start_column: number;
+  end_line: number;
+  end_column: number;
+  type: string;
+  message: string;
+};
+
+function parseFileAnnotations(stderr: string): null | FileAnnotation[] {
+  try {
+    return stderr
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as FileAnnotation);
+  } catch (_) {
+    return null;
+  }
+}
+
+function zipFiles(files: Record<string, string>): Uint8Array {
+  const utf8 = new TextEncoder();
+  const binaryFiles: Record<string, Uint8Array> = {};
+  for (const [name, content] of Object.entries(files)) {
+    binaryFiles[name] = utf8.encode(content);
+  }
+  return zipSync(binaryFiles);
+}

--- a/npm-packages/protocompile/src/compile.test.ts
+++ b/npm-packages/protocompile/src/compile.test.ts
@@ -1,0 +1,304 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { Edition, FileDescriptorProtoSchema } from "@bufbuild/protobuf/wkt";
+import {
+  compileEnum,
+  compileExtension,
+  compileFile,
+  compileFiles,
+  compileMessage,
+  compileMethod,
+  type CompileOptions,
+  compileService,
+} from "./compile.js";
+import type { BufBuildFlags } from "./buf-build.js";
+
+describe("compileFiles()", () => {
+  it("should compile each file", () => {
+    const reg = compileFiles({
+      "a.proto": `syntax="proto3"; message A {}`,
+      "b.proto": `syntax="proto3"; message B {}`,
+      "c.proto": `syntax="proto3"; message C {}`,
+    });
+    assert.ok(reg.getFile("a.proto") !== undefined);
+    assert.ok(reg.getFile("b.proto") !== undefined);
+    assert.ok(reg.getFile("c.proto") !== undefined);
+  });
+});
+
+describe("compileFile()", () => {
+  it("should compile file", () => {
+    const file = compileFile(`syntax="proto3";`);
+    assert.equal(file.edition, Edition.EDITION_PROTO3);
+  });
+  it("should compile file with imports", () => {
+    const imports = {
+      "input.proto": `syntax="proto3";`,
+    };
+    const file = compileFile(`syntax="proto3"; import "input.proto";`, {
+      imports,
+    });
+    assert.equal(file.kind, "file");
+    assert.equal(file.proto.name, "input1.proto");
+    assert.equal(file.dependencies.length, 1);
+    assert.equal(file.dependencies[0].proto.name, "input.proto");
+  });
+  it("should compile with source code info", () => {
+    const file = compileFile(`syntax="proto3"; package test;`);
+    const packageLocation = file.proto.sourceCodeInfo?.location.filter(
+      (l) =>
+        l.path.length == 1 &&
+        l.path[0] === FileDescriptorProtoSchema.field.package.number,
+    );
+    assert.ok(packageLocation !== undefined);
+  });
+  it("should honor excludeSourceInfo", () => {
+    const flags: BufBuildFlags = {
+      excludeSourceInfo: true,
+    };
+    const file = compileFile(`syntax="proto3"; package test;`, { flags });
+    const packageLocation = file.proto.sourceCodeInfo?.location.filter(
+      (l) =>
+        l.path.length == 1 &&
+        l.path[0] === FileDescriptorProtoSchema.field.package.number,
+    );
+    assert.ok(packageLocation === undefined);
+  });
+});
+
+describe("compileEnum()", () => {
+  it("should compile enum", () => {
+    const descEnum = compileEnum(`
+      syntax="proto3"; 
+      enum E {
+        E_UNSPECIFIED = 0;
+      }
+    `);
+    assert.equal(descEnum.kind, "enum");
+    assert.equal(descEnum.name, "E");
+  });
+  it("should accept options", () => {
+    const proto = `
+      syntax="proto3"; 
+      enum E {
+        E_UNSPECIFIED = 0;
+      }
+    `;
+    const opt: CompileOptions = {
+      imports: {
+        "foo.proto": `syntax="proto3";`,
+      },
+    };
+    compileEnum(proto, opt);
+  });
+  it("should error on missing definition", () => {
+    assert.throws(
+      () => compileEnum(`syntax="proto3";`),
+      /input must define exactly 1 enum, got 0/,
+    );
+  });
+  it("should error for too many definitions", () => {
+    assert.throws(
+      () =>
+        compileEnum(`
+      syntax="proto3";
+      enum A { A_UNSPECIFIED = 0; }
+      enum B { B_UNSPECIFIED = 0; }
+    `),
+      /input must define exactly 1 enum, got 2/,
+    );
+  });
+});
+
+describe("compileMessage()", () => {
+  const proto = `
+    syntax="proto3"; 
+    message M {}
+  `;
+  it("should compile message", () => {
+    const message = compileMessage(proto);
+    assert.equal(message.kind, "message");
+    assert.equal(message.name, "M");
+  });
+  it("should accept options", () => {
+    const opt: CompileOptions = {
+      imports: {
+        "foo.proto": `syntax="proto3";`,
+      },
+    };
+    compileMessage(proto, opt);
+  });
+  it("should error on missing definition", () => {
+    assert.throws(
+      () => compileMessage(`syntax="proto3";`),
+      /input must define exactly 1 message, got 0/,
+    );
+  });
+  it("should error for too many definitions", () => {
+    assert.throws(
+      () =>
+        compileMessage(`
+      syntax="proto3";
+      message A {}
+      message B {}
+    `),
+      /input must define exactly 1 message, got 2/,
+    );
+  });
+});
+
+describe("compileExtension()", () => {
+  const proto = `
+    syntax="proto3"; 
+    import "google/protobuf/descriptor.proto";
+    extend google.protobuf.FileOptions {
+      string foo = 1000;
+    } 
+  `;
+  it("should compile extension", () => {
+    const ext = compileExtension(proto);
+    assert.equal(ext.kind, "extension");
+    assert.equal(ext.name, "foo");
+  });
+  it("should accept options", () => {
+    const opt: CompileOptions = {
+      imports: {
+        "foo.proto": `syntax="proto3";`,
+      },
+    };
+    compileExtension(proto, opt);
+  });
+  it("should error on missing definition", () => {
+    assert.throws(
+      () =>
+        compileExtension(`
+      syntax="proto3";
+    `),
+      /input must define exactly 1 extension, got 0/,
+    );
+  });
+  it("should error for too many definitions", () => {
+    assert.throws(
+      () =>
+        compileExtension(`
+      syntax="proto3";
+      import "google/protobuf/descriptor.proto";
+      extend google.protobuf.FileOptions {
+        string a = 1000;
+        string b = 1001;
+      } 
+    `),
+      /input must define exactly 1 extension, got 2/,
+    );
+  });
+});
+
+describe("compileService()", () => {
+  const proto = `
+    syntax="proto3"; 
+    service FooService {}
+  `;
+  it("should compile service", () => {
+    const service = compileService(proto);
+    assert.equal(service.kind, "service");
+    assert.equal(service.name, "FooService");
+  });
+  it("should accept options", () => {
+    const opt: CompileOptions = {
+      imports: {
+        "foo.proto": `syntax="proto3";`,
+      },
+    };
+    compileService(proto, opt);
+  });
+  it("should error on missing definition", () => {
+    assert.throws(
+      () => compileService(`syntax="proto3";`),
+      /input must define exactly 1 service, got 0/,
+    );
+  });
+  it("should error for too many definitions", () => {
+    assert.throws(
+      () =>
+        compileService(`
+      syntax="proto3";
+      service A {}
+      service B {}
+    `),
+      /input must define exactly 1 service, got 2/,
+    );
+  });
+});
+
+describe("compileMethod()", () => {
+  const proto = `
+    syntax="proto3"; 
+    service FooService {
+      rpc Foo(I) returns (O);
+    }
+    message I {}
+    message O {}
+  `;
+  it("should compile method", () => {
+    const method = compileMethod(proto);
+    assert.equal(method.kind, "rpc");
+    assert.equal(method.name, "Foo");
+  });
+  it("should accept options", () => {
+    const opt: CompileOptions = {
+      imports: {
+        "foo.proto": `syntax="proto3";`,
+      },
+    };
+    compileMethod(proto, opt);
+  });
+  it("should accept kind", () => {
+    const methodKind: "unary" = compileMethod(proto, "unary").methodKind;
+    assert.equal(methodKind, "unary");
+  });
+  it("should accept kind and options", () => {
+    const opt: CompileOptions = {
+      imports: {
+        "foo.proto": `syntax="proto3";`,
+      },
+    };
+    const methodKind: "unary" = compileMethod(proto, "unary", opt).methodKind;
+    assert.equal(methodKind, "unary");
+  });
+  it("should error on missing parent definition", () => {
+    assert.throws(
+      () => compileMethod(`syntax="proto3";`),
+      /input must define exactly 1 service, got 0/,
+    );
+  });
+  it("should error on missing definition", () => {
+    assert.throws(
+      () =>
+        compileMethod(`
+      syntax="proto3";
+      service A {}
+    `),
+      /input must define exactly 1 rpc, got 0/,
+    );
+  });
+  it("should error for too many definitions", () => {
+    assert.throws(
+      () =>
+        compileMethod(`
+      syntax="proto3";
+      service S {
+        rpc A(M) returns (M);
+        rpc B(M) returns (M);
+      }
+      message M {}
+    `),
+      /input must define exactly 1 rpc, got 2/,
+    );
+  });
+  it("should error for unexpected kind", () => {
+    assert.throws(
+      () => compileMethod(proto, "server_streaming"),
+      /input must define server_streaming rpc, got unary/,
+    );
+  });
+});

--- a/npm-packages/protocompile/src/compile.test.ts
+++ b/npm-packages/protocompile/src/compile.test.ts
@@ -1,3 +1,17 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { Edition, FileDescriptorProtoSchema } from "@bufbuild/protobuf/wkt";

--- a/npm-packages/protocompile/src/compile.ts
+++ b/npm-packages/protocompile/src/compile.ts
@@ -113,7 +113,7 @@ export function compileMethod<Kind extends DescMethod["methodKind"]>(
   proto: string,
   methodKind: Kind,
   options?: CompileOptions,
-): DescMethod & { methodKind: Kind };
+): Omit<DescMethod, "methodKind"> & { readonly methodKind: Kind };
 
 export function compileMethod(
   proto: string,

--- a/npm-packages/protocompile/src/compile.ts
+++ b/npm-packages/protocompile/src/compile.ts
@@ -1,3 +1,17 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   createFileRegistry,
   type DescEnum,

--- a/npm-packages/protocompile/src/compile.ts
+++ b/npm-packages/protocompile/src/compile.ts
@@ -1,0 +1,168 @@
+import {
+  createFileRegistry,
+  type DescEnum,
+  type DescExtension,
+  type DescFile,
+  type DescMessage,
+  type DescMethod,
+  type DescService,
+  type FileRegistry,
+  fromBinary,
+} from "@bufbuild/protobuf";
+import { FileDescriptorSetSchema } from "@bufbuild/protobuf/wkt";
+import { bufBuild, type BufBuildFlags } from "./buf-build.js";
+
+export type CompileOptions = {
+  /**
+   * Flags to pass to `buf build`.
+   */
+  flags?: BufBuildFlags;
+  /**
+   * Protobuf files that the input imports.
+   */
+  imports?: Record<string, string>;
+};
+
+/**
+ * Compile an enumeration.
+ */
+export function compileEnum(proto: string, options?: CompileOptions): DescEnum {
+  const file = compileFile(proto, options);
+  if (file.enums.length != 1) {
+    throw new Error(
+      `input must define exactly 1 enum, got ${file.enums.length}`,
+    );
+  }
+  return file.enums[0];
+}
+
+/**
+ * Compile a message.
+ */
+export function compileMessage(
+  proto: string,
+  options?: CompileOptions,
+): DescMessage {
+  const file = compileFile(proto, options);
+  if (file.messages.length != 1) {
+    throw new Error(
+      `input must define exactly 1 message, got ${file.messages.length}`,
+    );
+  }
+  return file.messages[0];
+}
+
+/**
+ * Compile an extension.
+ */
+export function compileExtension(
+  proto: string,
+  options?: CompileOptions,
+): DescExtension {
+  const file = compileFile(proto, options);
+  if (file.extensions.length != 1) {
+    throw new Error(
+      `input must define exactly 1 extension, got ${file.extensions.length}`,
+    );
+  }
+  return file.extensions[0];
+}
+
+/**
+ * Compile a service.
+ */
+export function compileService(
+  proto: string,
+  options?: CompileOptions,
+): DescService {
+  const file = compileFile(proto, options);
+  if (file.services.length != 1) {
+    throw new Error(
+      `input must define exactly 1 service, got ${file.services.length}`,
+    );
+  }
+  return file.services[0];
+}
+
+/**
+ * Compile an RPC.
+ */
+export function compileMethod(
+  proto: string,
+  options?: CompileOptions,
+): DescMethod;
+
+/**
+ * Compile an RPC with a specific streaming type.
+ */
+export function compileMethod<Kind extends DescMethod["methodKind"]>(
+  proto: string,
+  methodKind: Kind,
+  options?: CompileOptions,
+): DescMethod & { methodKind: Kind };
+
+export function compileMethod(
+  proto: string,
+  methodKindOrOptions?: string | CompileOptions,
+  options?: CompileOptions,
+): DescMethod {
+  const opt: CompileOptions | undefined =
+    typeof methodKindOrOptions == "string" ? options : methodKindOrOptions;
+  const methodKind =
+    typeof methodKindOrOptions == "string"
+      ? (methodKindOrOptions as DescMethod["methodKind"])
+      : undefined;
+  const service = compileService(proto, opt);
+  if (service.methods.length != 1) {
+    throw new Error(
+      `input must define exactly 1 rpc, got ${service.methods.length}`,
+    );
+  }
+  const method = service.methods[0];
+  if (methodKind !== undefined && method.methodKind !== methodKind) {
+    throw new Error(
+      `input must define ${methodKind} rpc, got ${method.methodKind}`,
+    );
+  }
+  return method;
+}
+
+/**
+ * Compile a file.
+ */
+export function compileFile(proto: string, options?: CompileOptions): DescFile {
+  const [inputName, files] = getFiles(proto, options?.imports);
+  const registry = compileFiles(files, options?.flags);
+  const file = registry.getFile(inputName);
+  if (!file) {
+    throw new Error(`missing file ${inputName}`);
+  }
+  return file;
+}
+
+/**
+ * Compile multiple files to a registry.
+ */
+export function compileFiles(
+  files: Record<string, string>,
+  flags?: BufBuildFlags,
+): FileRegistry {
+  const bytes = bufBuild(files, flags);
+  const fileDescriptorSet = fromBinary(FileDescriptorSetSchema, bytes);
+  return createFileRegistry(fileDescriptorSet);
+}
+
+function getFiles(
+  proto: string,
+  imports: Record<string, string> | undefined,
+): [inputName: string, files: Record<string, string>] {
+  const files: Record<string, string> = {
+    ...imports,
+  };
+  let inputName = "input.proto";
+  for (let i = 1; Object.prototype.hasOwnProperty.call(files, inputName); i++) {
+    inputName = `input${i}.proto`;
+  }
+  files[inputName] = proto;
+  return [inputName, files];
+}

--- a/npm-packages/protocompile/src/example.test.ts
+++ b/npm-packages/protocompile/src/example.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from "node:test";
+import { compileMessage } from "./compile.js";
+import {
+  create,
+  type DescMessage,
+  type Message,
+  type MessageShape,
+} from "@bufbuild/protobuf";
+import assert from "node:assert/strict";
+import { reflect } from "@bufbuild/protobuf/reflect";
+
+describe("example", () => {
+  it("should work as documented", () => {
+    const schema = compileMessage(`
+      syntax = "proto3";
+      message Example {
+        string foo = 1 [ debug_redact = true ];
+      }
+    `);
+    const message: Message & Record<string, unknown> = create(schema, {
+      foo: "abc",
+    });
+    redact(schema, message);
+    expect(message.foo).toBe("");
+  });
+});
+
+function expect(act: unknown) {
+  return {
+    toBe(exp: unknown) {
+      assert.equal(act, exp);
+    },
+  };
+}
+
+function redact<Desc extends DescMessage>(
+  schema: Desc,
+  message: MessageShape<Desc>,
+): void {
+  const r = reflect(schema, message);
+  for (const f of r.fields) {
+    if (r.isSet(f) && f.proto.options?.debugRedact === true) {
+      r.clear(f);
+    }
+  }
+}

--- a/npm-packages/protocompile/src/example.test.ts
+++ b/npm-packages/protocompile/src/example.test.ts
@@ -1,3 +1,17 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { describe, it } from "node:test";
 import { compileMessage } from "./compile.js";
 import {

--- a/npm-packages/protocompile/src/index.ts
+++ b/npm-packages/protocompile/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./compile.js";
+export type { BufBuildFlags } from "./buf-build.js";

--- a/npm-packages/protocompile/src/index.ts
+++ b/npm-packages/protocompile/src/index.ts
@@ -1,2 +1,16 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export * from "./compile.js";
 export type { BufBuildFlags } from "./buf-build.js";

--- a/npm-packages/protocompile/tsconfig.cjs.json
+++ b/npm-packages/protocompile/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "files": ["src/index.ts"],
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "verbatimModuleSyntax": false,
+    "module": "commonjs",
+    "moduleResolution": "node10"
+  }
+}

--- a/npm-packages/protocompile/tsconfig.esm.json
+++ b/npm-packages/protocompile/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "files": ["src/index.ts"],
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm"
+  }
+}

--- a/npm-packages/protocompile/tsconfig.json
+++ b/npm-packages/protocompile/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "moduleResolution": "Node16",
+    "module": "Node16",
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "useUnknownInCatchVariables": true,
+    "noUnusedLocals": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "private": true,
   "workspaces": [
-    "./npm-packages/license-header"
+    "./npm-packages/license-header",
+    "./npm-packages/protocompile"
   ],
   "scripts": {
+    "all": "npm run -ws all",
     "test": "npm run -ws test --if-present",
     "generate": "npm run -ws generate --if-present"
   },


### PR DESCRIPTION
This package provides an API to compile Protobuf code to a [descriptor](https://github.com/bufbuild/protobuf-es/blob/main/MANUAL.md#descriptors). It provides a replacement for the `makeMessageType` API in protobuf-es v1. 